### PR TITLE
fix >16:9 aspect ratio for .gfx

### DIFF
--- a/instructional-buttons/cl_instructions.lua
+++ b/instructional-buttons/cl_instructions.lua
@@ -18,6 +18,9 @@ local function setupScaleform(scaleform, data)
     while not HasScaleformMovieLoaded(scaleform) do
         Citizen.Wait(0)
     end
+    
+    DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 0, 0)
+    
     PushScaleformMovieFunction(scaleform, "CLEAR_ALL")
     PopScaleformMovieFunctionVoid()
 


### PR DESCRIPTION
The game will set display configuration on first DrawScaleformMovieFullscreen call, but the code here only updates internal layout once, so it runs with an outdated display configuration.

Draw with a 0 alpha before doing anything depending on layout so that the game will set the display configuration first thing.